### PR TITLE
Add MPU6050 driver and clarify Unified Sensor description

### DIFF
--- a/0_2 Firmware/lib/Readme.md
+++ b/0_2 Firmware/lib/Readme.md
@@ -6,3 +6,5 @@ Las siguientes librerías son obligatorias para compilar el proyecto:
 3.  **Adafruit SSD1306** (Controlador de Pantalla OLED).
 4.  **Adafruit GFX** (Gráficos para pantalla).
 5.  **SdFat** (Gestión optimizada de tarjeta SD via SPI).
+6.  **Adrafruit MPU6050** (Driver del sensor IMU MPU6050).
+7.  **Adafruit Unified Sensor** (Capa base para sensores de Adafruit que estandariza la lectura de datos).


### PR DESCRIPTION
He agregado las librerías faltantes necesarias para el correcto desarrollo del proyecto, especialmente aquellas relacionadas con el control y la medición del ángulo de la jabalina mediante el sensor MPU6050.